### PR TITLE
Improve ReorderableWrap for full width widgets

### DIFF
--- a/lib/src/widgets/reorderable_wrap.dart
+++ b/lib/src/widgets/reorderable_wrap.dart
@@ -1037,24 +1037,22 @@ class _ReorderableWrapContentState extends State<_ReorderableWrapContent>
             Positioned(
                 left: 0,
                 top: 0,
-                width: widget.direction == Axis.horizontal
-                    ? _childSizes[index].width / 2
-                    : _childSizes[index].width,
-                height: widget.direction == Axis.vertical
-                    ? _childSizes[index].height / 2
-                    : _childSizes[index].height,
-                child: preDragTarget),
+                width: _childSizes[index].width,
+                height: _childSizes[index].height,
+                child: ClipPath(
+                  clipper: TopLeftTriangleClipper(),
+                  child: preDragTarget,
+                )),
           if (containedDraggable.isReorderable)
             Positioned(
                 right: 0,
                 bottom: 0,
-                width: widget.direction == Axis.horizontal
-                    ? _childSizes[index].width / 2
-                    : _childSizes[index].width,
-                height: widget.direction == Axis.vertical
-                    ? _childSizes[index].height / 2
-                    : _childSizes[index].height,
-                child: nextDragTarget),
+                width: _childSizes[index].width,
+                height: _childSizes[index].height,
+                child: ClipPath(
+                  clipper: BottomRightTriangleClipper(),
+                  child: nextDragTarget,
+                )),
         ],
       );
 //      return dragTarget;
@@ -1284,4 +1282,32 @@ class ContainedDraggable {
   bool isReorderable;
 
   ContainedDraggable(this.builder, this.isReorderable);
+}
+
+class TopLeftTriangleClipper extends CustomClipper<Path> {
+  @override
+  Path getClip(Size size) {
+    return Path()
+      ..moveTo(0, 0)
+      ..lineTo(size.width, 0)
+      ..lineTo(0, size.height)
+      ..close();
+  }
+
+  @override
+  bool shouldReclip(CustomClipper<Path> oldClipper) => false;
+}
+
+class BottomRightTriangleClipper extends CustomClipper<Path> {
+  @override
+  Path getClip(Size size) {
+    return Path()
+      ..moveTo(size.width, size.height)
+      ..lineTo(0, size.height)
+      ..lineTo(size.width, 0)
+      ..close();
+  }
+
+  @override
+  bool shouldReclip(CustomClipper<Path> oldClipper) => false;
 }


### PR DESCRIPTION
Changes the drag targets from two horizontal/vertical rectangles to two triangles covering the upper left side for the "preDragTarget" and the lower right side for the "nextDragTarget". When a reorderable widget expands to full width, it is now more intuitive to drag it to the previous/next position.

For example, without this change, the user always had to drag the widget to the left to move it to the previous position when horizontal mode was enabled. Now it is possible to simply drag it upwards on the right side of the widget.